### PR TITLE
Switch cas library to our own fork

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -2,7 +2,7 @@ package server
 
 import (
 	log "github.com/Sirupsen/logrus"
-	"github.com/binjianwu/cas"
+	"github.com/TheGuyWithTheFace/cas"
 	"github.com/casey-chow/tigertrade/server/models"
 	"github.com/getsentry/raven-go"
 	"github.com/julienschmidt/httprouter"

--- a/server/main.go
+++ b/server/main.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"flag"
 	log "github.com/Sirupsen/logrus"
-	"github.com/binjianwu/cas" // NOTE: use this until https://github.com/go-cas/cas/pull/10 is merged
+	"github.com/TheGuyWithTheFace/cas" // NOTE: use this until https://github.com/go-cas/cas/pull/10 and pytimer's fork are merged
 	"github.com/getsentry/raven-go"
 	_ "github.com/lib/pq"
 	"github.com/meatballhat/negroni-logrus"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -18,12 +18,10 @@
 			"revisionTime": "2017-03-17T14:32:14Z"
 		},
 		{
-			"checksumSHA1": "jSUUz/39owlzxbRV3/lnDsbtFCQ=",
-			"path": "github.com/binjianwu/cas",
-			"revision": "06985ad899c2f6162b10ae64c5c0cb4775b28569",
-			"revisionTime": "2017-02-18T02:49:32Z",
-			"version": "logout-param",
-			"versionExact": "logout-param"
+			"checksumSHA1": "W8pk3fX1cuesf4jsL/UQPlaE8D0=",
+			"path": "github.com/TheGuyWithTheFace/cas",
+			"revision": "f6e470983e0b51e078d1b598baa7a1dc92884f22",
+			"revisionTime": "2017-04-20T04:46:58Z"
 		},
 		{
 			"checksumSHA1": "xTy1x4EoWRSsBlstJxFp0z321NQ=",


### PR DESCRIPTION
This fork includes changes made in two separate forks of the project
that we need and have not been merged yet. If they ever are merged back
into the official project, we should switch cas back to track the
official go-cas/cas.

Closes #83