### PR TITLE
Add starring functionality and refactor search queries

### DIFF
--- a/server/database.sql
+++ b/server/database.sql
@@ -5,7 +5,7 @@
 -- Dumped from database version 9.6.1
 -- Dumped by pg_dump version 9.6.1
 
--- Started on 2017-04-24 01:28:58 EDT
+-- Started on 2017-04-28 01:22:07 EDT
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -25,7 +25,7 @@ CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 
 
 --
--- TOC entry 3131 (class 0 OID 0)
+-- TOC entry 3132 (class 0 OID 0)
 -- Dependencies: 1
 -- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
 --
@@ -86,7 +86,7 @@ CREATE SEQUENCE "listings-saved_searches_key_id_seq"
 
 
 --
--- TOC entry 3132 (class 0 OID 0)
+-- TOC entry 3133 (class 0 OID 0)
 -- Dependencies: 201
 -- Name: listings-saved_searches_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -108,7 +108,7 @@ CREATE SEQUENCE listings_key_id_seq
 
 
 --
--- TOC entry 3133 (class 0 OID 0)
+-- TOC entry 3134 (class 0 OID 0)
 -- Dependencies: 185
 -- Name: listings_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -145,7 +145,7 @@ CREATE SEQUENCE photos_key_id_seq
 
 
 --
--- TOC entry 3134 (class 0 OID 0)
+-- TOC entry 3135 (class 0 OID 0)
 -- Dependencies: 193
 -- Name: photos_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -186,7 +186,7 @@ CREATE SEQUENCE saved_searches_key_id_seq
 
 
 --
--- TOC entry 3135 (class 0 OID 0)
+-- TOC entry 3136 (class 0 OID 0)
 -- Dependencies: 195
 -- Name: saved_searches_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -227,7 +227,7 @@ CREATE SEQUENCE seeks_key_id_seq
 
 
 --
--- TOC entry 3136 (class 0 OID 0)
+-- TOC entry 3137 (class 0 OID 0)
 -- Dependencies: 187
 -- Name: seeks_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -263,7 +263,7 @@ CREATE SEQUENCE starred_listings_key_id_seq
 
 
 --
--- TOC entry 3137 (class 0 OID 0)
+-- TOC entry 3138 (class 0 OID 0)
 -- Dependencies: 205
 -- Name: starred_listings_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -311,7 +311,7 @@ CREATE SEQUENCE "tags-listings_key_id_seq"
 
 
 --
--- TOC entry 3138 (class 0 OID 0)
+-- TOC entry 3139 (class 0 OID 0)
 -- Dependencies: 197
 -- Name: tags-listings_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -346,7 +346,7 @@ CREATE SEQUENCE "tags-saved_searches_key_id_seq"
 
 
 --
--- TOC entry 3139 (class 0 OID 0)
+-- TOC entry 3140 (class 0 OID 0)
 -- Dependencies: 199
 -- Name: tags-saved_searches_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -368,7 +368,7 @@ CREATE SEQUENCE tags_key_id_seq
 
 
 --
--- TOC entry 3140 (class 0 OID 0)
+-- TOC entry 3141 (class 0 OID 0)
 -- Dependencies: 191
 -- Name: tags_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -404,7 +404,7 @@ CREATE SEQUENCE thumbnails_key_id_seq
 
 
 --
--- TOC entry 3141 (class 0 OID 0)
+-- TOC entry 3142 (class 0 OID 0)
 -- Dependencies: 203
 -- Name: thumbnails_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -422,7 +422,8 @@ CREATE TABLE users (
     creation_date timestamp with time zone DEFAULT now(),
     last_modification_date timestamp with time zone,
     net_id character varying(8) NOT NULL,
-    CONSTRAINT nonempty_net_id CHECK (((net_id)::text <> ''::text))
+    CONSTRAINT nonempty_net_id CHECK (((net_id)::text <> ''::text)),
+    CONSTRAINT "positive key_id" CHECK ((key_id > 0))
 );
 
 
@@ -440,7 +441,7 @@ CREATE SEQUENCE users_key_id_seq
 
 
 --
--- TOC entry 3142 (class 0 OID 0)
+-- TOC entry 3143 (class 0 OID 0)
 -- Dependencies: 189
 -- Name: users_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -457,7 +458,7 @@ ALTER TABLE ONLY listings ALTER COLUMN key_id SET DEFAULT nextval('listings_key_
 
 
 --
--- TOC entry 2976 (class 2604 OID 4640488)
+-- TOC entry 2977 (class 2604 OID 4640488)
 -- Name: listings-saved_searches key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -465,7 +466,7 @@ ALTER TABLE ONLY "listings-saved_searches" ALTER COLUMN key_id SET DEFAULT nextv
 
 
 --
--- TOC entry 2966 (class 2604 OID 4640006)
+-- TOC entry 2967 (class 2604 OID 4640006)
 -- Name: photos key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -473,7 +474,7 @@ ALTER TABLE ONLY photos ALTER COLUMN key_id SET DEFAULT nextval('photos_key_id_s
 
 
 --
--- TOC entry 2969 (class 2604 OID 4640391)
+-- TOC entry 2970 (class 2604 OID 4640391)
 -- Name: saved_searches key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -489,7 +490,7 @@ ALTER TABLE ONLY seeks ALTER COLUMN key_id SET DEFAULT nextval('seeks_key_id_seq
 
 
 --
--- TOC entry 2981 (class 2604 OID 5649587)
+-- TOC entry 2982 (class 2604 OID 5649587)
 -- Name: starred_listings key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -497,7 +498,7 @@ ALTER TABLE ONLY starred_listings ALTER COLUMN key_id SET DEFAULT nextval('starr
 
 
 --
--- TOC entry 2964 (class 2604 OID 4639971)
+-- TOC entry 2965 (class 2604 OID 4639971)
 -- Name: tags key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -505,7 +506,7 @@ ALTER TABLE ONLY tags ALTER COLUMN key_id SET DEFAULT nextval('tags_key_id_seq':
 
 
 --
--- TOC entry 2972 (class 2604 OID 4640443)
+-- TOC entry 2973 (class 2604 OID 4640443)
 -- Name: tags-listings key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -513,7 +514,7 @@ ALTER TABLE ONLY "tags-listings" ALTER COLUMN key_id SET DEFAULT nextval('"tags-
 
 
 --
--- TOC entry 2974 (class 2604 OID 4640457)
+-- TOC entry 2975 (class 2604 OID 4640457)
 -- Name: tags-saved_searches key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -521,7 +522,7 @@ ALTER TABLE ONLY "tags-saved_searches" ALTER COLUMN key_id SET DEFAULT nextval('
 
 
 --
--- TOC entry 2978 (class 2604 OID 4758083)
+-- TOC entry 2979 (class 2604 OID 4758083)
 -- Name: thumbnails key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -537,7 +538,7 @@ ALTER TABLE ONLY users ALTER COLUMN key_id SET DEFAULT nextval('users_key_id_seq
 
 
 --
--- TOC entry 3003 (class 2606 OID 4640491)
+-- TOC entry 3004 (class 2606 OID 4640491)
 -- Name: listings-saved_searches listings-saved_searches_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -546,7 +547,7 @@ ALTER TABLE ONLY "listings-saved_searches"
 
 
 --
--- TOC entry 2985 (class 2606 OID 4639385)
+-- TOC entry 2986 (class 2606 OID 4639385)
 -- Name: listings listings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -555,7 +556,7 @@ ALTER TABLE ONLY listings
 
 
 --
--- TOC entry 2995 (class 2606 OID 4640009)
+-- TOC entry 2996 (class 2606 OID 4640009)
 -- Name: photos photos_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -564,7 +565,7 @@ ALTER TABLE ONLY photos
 
 
 --
--- TOC entry 2997 (class 2606 OID 4640398)
+-- TOC entry 2998 (class 2606 OID 4640398)
 -- Name: saved_searches saved_searches_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -573,7 +574,7 @@ ALTER TABLE ONLY saved_searches
 
 
 --
--- TOC entry 2987 (class 2606 OID 4639459)
+-- TOC entry 2988 (class 2606 OID 4639459)
 -- Name: seeks seeks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -582,7 +583,7 @@ ALTER TABLE ONLY seeks
 
 
 --
--- TOC entry 3007 (class 2606 OID 5649589)
+-- TOC entry 3008 (class 2606 OID 5649589)
 -- Name: starred_listings starred_listings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -591,7 +592,7 @@ ALTER TABLE ONLY starred_listings
 
 
 --
--- TOC entry 2999 (class 2606 OID 4640446)
+-- TOC entry 3000 (class 2606 OID 4640446)
 -- Name: tags-listings tags-listings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -600,7 +601,7 @@ ALTER TABLE ONLY "tags-listings"
 
 
 --
--- TOC entry 3001 (class 2606 OID 4640460)
+-- TOC entry 3002 (class 2606 OID 4640460)
 -- Name: tags-saved_searches tags-saved_searches_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -609,7 +610,7 @@ ALTER TABLE ONLY "tags-saved_searches"
 
 
 --
--- TOC entry 2991 (class 2606 OID 4639974)
+-- TOC entry 2992 (class 2606 OID 4639974)
 -- Name: tags tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -618,7 +619,7 @@ ALTER TABLE ONLY tags
 
 
 --
--- TOC entry 3005 (class 2606 OID 4758090)
+-- TOC entry 3006 (class 2606 OID 4758090)
 -- Name: thumbnails thumbnails_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -627,7 +628,7 @@ ALTER TABLE ONLY thumbnails
 
 
 --
--- TOC entry 2993 (class 2606 OID 4640149)
+-- TOC entry 2994 (class 2606 OID 4640149)
 -- Name: tags uniq_name; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -636,7 +637,7 @@ ALTER TABLE ONLY tags
 
 
 --
--- TOC entry 2989 (class 2606 OID 4639703)
+-- TOC entry 2990 (class 2606 OID 4639703)
 -- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -644,7 +645,7 @@ ALTER TABLE ONLY users
     ADD CONSTRAINT users_pkey PRIMARY KEY (key_id);
 
 
--- Completed on 2017-04-24 01:29:01 EDT
+-- Completed on 2017-04-28 01:22:12 EDT
 
 --
 -- PostgreSQL database dump complete

--- a/server/helpers.go
+++ b/server/helpers.go
@@ -10,15 +10,6 @@ import (
 	"strings"
 )
 
-// Maximum number of characters in a truncated description of a datum
-// Used when obtaining and displaying many datum of a given structure
-const truncationLength = 1024
-
-// Default and maximum number of datum returned by bulk API queries
-// Used when obtaining and displaying many datum of a given structure
-const defaultNumResults = 30
-const maxNumResults = 100
-
 // Serve converts v to a JSON string and writes to w.
 // Writes an InternalServerError on error.
 func Serve(w http.ResponseWriter, v interface{}) {

--- a/server/listings_test.go
+++ b/server/listings_test.go
@@ -71,11 +71,11 @@ func TestSearch(t *testing.T) {
 				WillReturnRows(sqlmock.NewRows([]string{
 					"listings.key_id", "listings.creation_date", "listings.last_modification_date",
 					"title", "description", "user_id",
-					"price", "status", "expiration_date", "thumbnails.url",
+					"price", "status", "expiration_date", "thumbnails.url", "starred_listings.is_starred",
 				}).AddRow(
 					1, time.Now(), time.Now(),
 					"SampleValue", "Sampleish Value!",
-					1, 1001, "For Sale", time.Now(), "http://example.com/asf.gif",
+					1, 1001, "For Sale", time.Now(), "http://example.com/asf.gif", false,
 				))
 
 			req, _ := http.NewRequest("GET", "/api/listings?query=SampleValue", nil)
@@ -104,11 +104,11 @@ func TestSearch(t *testing.T) {
 				WillReturnRows(sqlmock.NewRows([]string{
 					"listings.key_id", "listings.creation_date", "listings.last_modification_date",
 					"title", "description", "user_id",
-					"price", "status", "expiration_date", "thumbnails.url",
+					"price", "status", "expiration_date", "thumbnails.url", "starred_listings.is_starred",
 				}).AddRow(
 					1, time.Now(), time.Now(),
 					"SampleValue", "Sampleish Value!",
-					1, 1001, "For Sale", time.Now(), "http://example.com/asf.gif",
+					1, 1001, "For Sale", time.Now(), "http://example.com/asf.gif", false,
 				))
 
 			req, _ := http.NewRequest("GET", "/api/listings?query=sAmPleVaLue", nil)

--- a/server/models/helpers.go
+++ b/server/models/helpers.go
@@ -6,6 +6,15 @@ import (
 	"net/http"
 )
 
+// Maximum number of characters in a truncated description of a datum
+// Used when obtaining and displaying many datum of a given structure
+const truncationLength = 1024
+
+// Default and maximum number of datum returned by bulk API queries
+// Used when obtaining and displaying many datum of a given structure
+const defaultNumResults uint64 = 30
+const maxNumResults uint64 = 100
+
 func getUpdateResultCode(result sql.Result, err error) (int, error) {
 
 	if err != nil {

--- a/server/models/seeks.go
+++ b/server/models/seeks.go
@@ -36,28 +36,43 @@ type Seek struct {
 	Status               null.String `json:"status"`
 }
 
+type seekQuery struct {
+	Query string
+	Limit uint64
+}
+
+func NewSeekQuery() *seekQuery {
+	q := new(seekQuery)
+	q.Limit = defaultNumResults
+	return q
+}
+
 // Returns the most recent count seeks, based on original date created.
 // If queryStr is nonempty, filters that every returned item must have every word in either title or description
 // On error, returns an error and the HTTP code associated with that error.
-func ReadSeeks(db *sql.DB, queryStr string, maxDescriptionSize int, limit uint64) ([]*SeeksItem, error, int) {
-	// Create seeks query
-	query := psql.
+func ReadSeeks(db *sql.DB, query *seekQuery) ([]*SeeksItem, error, int) {
+	// Create seeks statement
+	stmt := psql.
 		Select("seeks.key_id", "seeks.creation_date", "seeks.last_modification_date",
-			"title", fmt.Sprintf("left(description, %d)", maxDescriptionSize),
+			"title", fmt.Sprintf("left(description, %d)", truncationLength),
 			"user_id", "saved_search_id", "notify_enabled", "status").
 		From("seeks").
 		Where("seeks.is_active=true")
 
-	for i, word := range strings.Fields(queryStr) {
-		query = query.Where(fmt.Sprintf("(lower(seeks.title) LIKE lower($%d) OR lower(seeks.description) LIKE lower($%d))", i+1, i+1), fmt.Sprint("%", word, "%"))
+	for i, word := range strings.Fields(query.Query) {
+		stmt = stmt.Where(fmt.Sprintf("(lower(seeks.title) LIKE lower($%d) OR lower(seeks.description) LIKE lower($%d))", i+1, i+1), fmt.Sprint("%", word, "%"))
 	}
 
-	query = query.
-		OrderBy("seeks.creation_date DESC").
-		Limit(limit)
+	stmt = stmt.OrderBy("seeks.creation_date DESC")
+
+	if query.Limit <= maxNumResults {
+		stmt = stmt.Limit(query.Limit)
+	} else {
+		stmt = stmt.Limit(maxNumResults)
+	}
 
 	// Query db
-	rows, err := query.RunWith(db).Query()
+	rows, err := stmt.RunWith(db).Query()
 	if err != nil {
 		return nil, err, http.StatusInternalServerError
 	}

--- a/server/router.go
+++ b/server/router.go
@@ -26,7 +26,7 @@ func Router() http.Handler {
 	router.POST("/api/listings", CreateListing)
 	router.GET("/api/listings/:id", ReadListing)
 	router.POST("/api/listings/:id", UpdateListing)
-	router.POST("/api/listings/:id/isstarred", UpdateIsStarred)
+	router.POST("/api/listings/:id/star", UpdateListingStar)
 	router.DELETE("/api/listings/:id", DeleteListing)
 
 	// photos.go


### PR DESCRIPTION
Add starring functionality

To filter by whether the listings are starred or not (as in the case of a "my favorites" page or similar),
add isStarred=true as a GET param to /api/listings.
(if the user is not logged in, this parameter is ignored.)

To add (or remove) a star to/from a listing,
POST /api/listings/:id/star
with the following body:
{"isStarred":true} (or false to remove)

Closes #108 by refactoring search queries into a struct