### PR TITLE
Removed unused table/columns from database

### DIFF
--- a/server/database.sql
+++ b/server/database.sql
@@ -3,9 +3,9 @@
 --
 
 -- Dumped from database version 9.6.1
--- Dumped by pg_dump version 9.6.1
+-- Dumped by pg_dump version 9.6.2
 
--- Started on 2017-05-04 02:18:52 EDT
+-- Started on 2017-05-07 23:09:15 EDT
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -25,7 +25,7 @@ CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 
 
 --
--- TOC entry 3123 (class 0 OID 0)
+-- TOC entry 3111 (class 0 OID 0)
 -- Dependencies: 1
 -- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
 --
@@ -55,7 +55,6 @@ CREATE TABLE listings (
     status character varying(20),
     expiration_date timestamp with time zone,
     is_active boolean DEFAULT true,
-    thumbnail_id bigint,
     photos text[] DEFAULT '{}'::text[],
     thumbnail_url character varying(2084)
 );
@@ -88,7 +87,7 @@ CREATE SEQUENCE "listings-saved_searches_key_id_seq"
 
 
 --
--- TOC entry 3124 (class 0 OID 0)
+-- TOC entry 3112 (class 0 OID 0)
 -- Dependencies: 199
 -- Name: listings-saved_searches_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -110,7 +109,7 @@ CREATE SEQUENCE listings_key_id_seq
 
 
 --
--- TOC entry 3125 (class 0 OID 0)
+-- TOC entry 3113 (class 0 OID 0)
 -- Dependencies: 185
 -- Name: listings_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -151,7 +150,7 @@ CREATE SEQUENCE saved_searches_key_id_seq
 
 
 --
--- TOC entry 3126 (class 0 OID 0)
+-- TOC entry 3114 (class 0 OID 0)
 -- Dependencies: 193
 -- Name: saved_searches_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -193,7 +192,7 @@ CREATE SEQUENCE seeks_key_id_seq
 
 
 --
--- TOC entry 3127 (class 0 OID 0)
+-- TOC entry 3115 (class 0 OID 0)
 -- Dependencies: 187
 -- Name: seeks_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -202,7 +201,7 @@ ALTER SEQUENCE seeks_key_id_seq OWNED BY seeks.key_id;
 
 
 --
--- TOC entry 204 (class 1259 OID 5649584)
+-- TOC entry 202 (class 1259 OID 5649584)
 -- Name: starred_listings; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -216,7 +215,7 @@ CREATE TABLE starred_listings (
 
 
 --
--- TOC entry 203 (class 1259 OID 5649582)
+-- TOC entry 201 (class 1259 OID 5649582)
 -- Name: starred_listings_key_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -229,8 +228,8 @@ CREATE SEQUENCE starred_listings_key_id_seq
 
 
 --
--- TOC entry 3128 (class 0 OID 0)
--- Dependencies: 203
+-- TOC entry 3116 (class 0 OID 0)
+-- Dependencies: 201
 -- Name: starred_listings_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
@@ -277,7 +276,7 @@ CREATE SEQUENCE "tags-listings_key_id_seq"
 
 
 --
--- TOC entry 3129 (class 0 OID 0)
+-- TOC entry 3117 (class 0 OID 0)
 -- Dependencies: 195
 -- Name: tags-listings_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -312,7 +311,7 @@ CREATE SEQUENCE "tags-saved_searches_key_id_seq"
 
 
 --
--- TOC entry 3130 (class 0 OID 0)
+-- TOC entry 3118 (class 0 OID 0)
 -- Dependencies: 197
 -- Name: tags-saved_searches_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -334,48 +333,12 @@ CREATE SEQUENCE tags_key_id_seq
 
 
 --
--- TOC entry 3131 (class 0 OID 0)
+-- TOC entry 3119 (class 0 OID 0)
 -- Dependencies: 191
 -- Name: tags_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE tags_key_id_seq OWNED BY tags.key_id;
-
-
---
--- TOC entry 202 (class 1259 OID 4758080)
--- Name: thumbnails; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE thumbnails (
-    key_id bigint NOT NULL,
-    creation_date timestamp with time zone DEFAULT now(),
-    last_modification_date timestamp with time zone,
-    is_active boolean DEFAULT true,
-    url character varying(2048) NOT NULL
-);
-
-
---
--- TOC entry 201 (class 1259 OID 4758078)
--- Name: thumbnails_key_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE thumbnails_key_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- TOC entry 3132 (class 0 OID 0)
--- Dependencies: 201
--- Name: thumbnails_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE thumbnails_key_id_seq OWNED BY thumbnails.key_id;
 
 
 --
@@ -408,7 +371,7 @@ CREATE SEQUENCE users_key_id_seq
 
 
 --
--- TOC entry 3133 (class 0 OID 0)
+-- TOC entry 3120 (class 0 OID 0)
 -- Dependencies: 189
 -- Name: users_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -417,7 +380,7 @@ ALTER SEQUENCE users_key_id_seq OWNED BY users.key_id;
 
 
 --
--- TOC entry 2948 (class 2604 OID 4639379)
+-- TOC entry 2941 (class 2604 OID 4639379)
 -- Name: listings key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -425,7 +388,7 @@ ALTER TABLE ONLY listings ALTER COLUMN key_id SET DEFAULT nextval('listings_key_
 
 
 --
--- TOC entry 2970 (class 2604 OID 4640488)
+-- TOC entry 2963 (class 2604 OID 4640488)
 -- Name: listings-saved_searches key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -433,7 +396,7 @@ ALTER TABLE ONLY "listings-saved_searches" ALTER COLUMN key_id SET DEFAULT nextv
 
 
 --
--- TOC entry 2963 (class 2604 OID 4640391)
+-- TOC entry 2956 (class 2604 OID 4640391)
 -- Name: saved_searches key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -441,7 +404,7 @@ ALTER TABLE ONLY saved_searches ALTER COLUMN key_id SET DEFAULT nextval('saved_s
 
 
 --
--- TOC entry 2952 (class 2604 OID 4639456)
+-- TOC entry 2945 (class 2604 OID 4639456)
 -- Name: seeks key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -449,7 +412,7 @@ ALTER TABLE ONLY seeks ALTER COLUMN key_id SET DEFAULT nextval('seeks_key_id_seq
 
 
 --
--- TOC entry 2975 (class 2604 OID 5649587)
+-- TOC entry 2965 (class 2604 OID 5649587)
 -- Name: starred_listings key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -457,7 +420,7 @@ ALTER TABLE ONLY starred_listings ALTER COLUMN key_id SET DEFAULT nextval('starr
 
 
 --
--- TOC entry 2961 (class 2604 OID 4639971)
+-- TOC entry 2954 (class 2604 OID 4639971)
 -- Name: tags key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -465,7 +428,7 @@ ALTER TABLE ONLY tags ALTER COLUMN key_id SET DEFAULT nextval('tags_key_id_seq':
 
 
 --
--- TOC entry 2966 (class 2604 OID 4640443)
+-- TOC entry 2959 (class 2604 OID 4640443)
 -- Name: tags-listings key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -473,7 +436,7 @@ ALTER TABLE ONLY "tags-listings" ALTER COLUMN key_id SET DEFAULT nextval('"tags-
 
 
 --
--- TOC entry 2968 (class 2604 OID 4640457)
+-- TOC entry 2961 (class 2604 OID 4640457)
 -- Name: tags-saved_searches key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -481,15 +444,7 @@ ALTER TABLE ONLY "tags-saved_searches" ALTER COLUMN key_id SET DEFAULT nextval('
 
 
 --
--- TOC entry 2972 (class 2604 OID 4758083)
--- Name: thumbnails key_id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY thumbnails ALTER COLUMN key_id SET DEFAULT nextval('thumbnails_key_id_seq'::regclass);
-
-
---
--- TOC entry 2956 (class 2604 OID 4639700)
+-- TOC entry 2949 (class 2604 OID 4639700)
 -- Name: users key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -497,7 +452,7 @@ ALTER TABLE ONLY users ALTER COLUMN key_id SET DEFAULT nextval('users_key_id_seq
 
 
 --
--- TOC entry 2995 (class 2606 OID 4640491)
+-- TOC entry 2985 (class 2606 OID 4640491)
 -- Name: listings-saved_searches listings-saved_searches_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -506,7 +461,7 @@ ALTER TABLE ONLY "listings-saved_searches"
 
 
 --
--- TOC entry 2979 (class 2606 OID 4639385)
+-- TOC entry 2969 (class 2606 OID 4639385)
 -- Name: listings listings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -515,7 +470,7 @@ ALTER TABLE ONLY listings
 
 
 --
--- TOC entry 2989 (class 2606 OID 4640398)
+-- TOC entry 2979 (class 2606 OID 4640398)
 -- Name: saved_searches saved_searches_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -524,7 +479,7 @@ ALTER TABLE ONLY saved_searches
 
 
 --
--- TOC entry 2981 (class 2606 OID 4639459)
+-- TOC entry 2971 (class 2606 OID 4639459)
 -- Name: seeks seeks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -533,7 +488,7 @@ ALTER TABLE ONLY seeks
 
 
 --
--- TOC entry 2999 (class 2606 OID 5649589)
+-- TOC entry 2987 (class 2606 OID 5649589)
 -- Name: starred_listings starred_listings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -542,7 +497,7 @@ ALTER TABLE ONLY starred_listings
 
 
 --
--- TOC entry 2991 (class 2606 OID 4640446)
+-- TOC entry 2981 (class 2606 OID 4640446)
 -- Name: tags-listings tags-listings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -551,7 +506,7 @@ ALTER TABLE ONLY "tags-listings"
 
 
 --
--- TOC entry 2993 (class 2606 OID 4640460)
+-- TOC entry 2983 (class 2606 OID 4640460)
 -- Name: tags-saved_searches tags-saved_searches_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -560,7 +515,7 @@ ALTER TABLE ONLY "tags-saved_searches"
 
 
 --
--- TOC entry 2985 (class 2606 OID 4639974)
+-- TOC entry 2975 (class 2606 OID 4639974)
 -- Name: tags tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -569,16 +524,7 @@ ALTER TABLE ONLY tags
 
 
 --
--- TOC entry 2997 (class 2606 OID 4758090)
--- Name: thumbnails thumbnails_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY thumbnails
-    ADD CONSTRAINT thumbnails_pkey PRIMARY KEY (key_id);
-
-
---
--- TOC entry 2987 (class 2606 OID 4640149)
+-- TOC entry 2977 (class 2606 OID 4640149)
 -- Name: tags uniq_name; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -587,7 +533,7 @@ ALTER TABLE ONLY tags
 
 
 --
--- TOC entry 2983 (class 2606 OID 4639703)
+-- TOC entry 2973 (class 2606 OID 4639703)
 -- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -595,7 +541,7 @@ ALTER TABLE ONLY users
     ADD CONSTRAINT users_pkey PRIMARY KEY (key_id);
 
 
--- Completed on 2017-05-04 02:18:55 EDT
+-- Completed on 2017-05-07 23:09:18 EDT
 
 --
 -- PostgreSQL database dump complete


### PR DESCRIPTION
Specifically, we no longer use the thumbnails table now that listings
have thumbnail_url as a property.