### PR TITLE
Add(ed) cache table new_listings

### DIFF
--- a/server/database.sql
+++ b/server/database.sql
@@ -5,7 +5,7 @@
 -- Dumped from database version 9.6.1
 -- Dumped by pg_dump version 9.6.2
 
--- Started on 2017-05-07 23:09:15 EDT
+-- Started on 2017-05-08 03:59:51 EDT
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -25,7 +25,7 @@ CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 
 
 --
--- TOC entry 3111 (class 0 OID 0)
+-- TOC entry 3121 (class 0 OID 0)
 -- Dependencies: 1
 -- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
 --
@@ -87,7 +87,7 @@ CREATE SEQUENCE "listings-saved_searches_key_id_seq"
 
 
 --
--- TOC entry 3112 (class 0 OID 0)
+-- TOC entry 3122 (class 0 OID 0)
 -- Dependencies: 199
 -- Name: listings-saved_searches_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -109,12 +109,33 @@ CREATE SEQUENCE listings_key_id_seq
 
 
 --
--- TOC entry 3113 (class 0 OID 0)
+-- TOC entry 3123 (class 0 OID 0)
 -- Dependencies: 185
 -- Name: listings_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE listings_key_id_seq OWNED BY listings.key_id;
+
+
+--
+-- TOC entry 203 (class 1259 OID 7022049)
+-- Name: new_listings; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE new_listings (
+    key_id bigint NOT NULL,
+    creation_date timestamp with time zone DEFAULT now(),
+    last_modification_date timestamp with time zone,
+    title character varying(140) NOT NULL,
+    description character varying(1000000),
+    user_id bigint NOT NULL,
+    price integer,
+    status character varying(20),
+    expiration_date timestamp with time zone,
+    is_active boolean DEFAULT true,
+    photos text[] DEFAULT '{}'::text[],
+    thumbnail_url character varying(2084)
+);
 
 
 --
@@ -150,7 +171,7 @@ CREATE SEQUENCE saved_searches_key_id_seq
 
 
 --
--- TOC entry 3114 (class 0 OID 0)
+-- TOC entry 3124 (class 0 OID 0)
 -- Dependencies: 193
 -- Name: saved_searches_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -192,7 +213,7 @@ CREATE SEQUENCE seeks_key_id_seq
 
 
 --
--- TOC entry 3115 (class 0 OID 0)
+-- TOC entry 3125 (class 0 OID 0)
 -- Dependencies: 187
 -- Name: seeks_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -228,7 +249,7 @@ CREATE SEQUENCE starred_listings_key_id_seq
 
 
 --
--- TOC entry 3116 (class 0 OID 0)
+-- TOC entry 3126 (class 0 OID 0)
 -- Dependencies: 201
 -- Name: starred_listings_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -276,7 +297,7 @@ CREATE SEQUENCE "tags-listings_key_id_seq"
 
 
 --
--- TOC entry 3117 (class 0 OID 0)
+-- TOC entry 3127 (class 0 OID 0)
 -- Dependencies: 195
 -- Name: tags-listings_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -311,7 +332,7 @@ CREATE SEQUENCE "tags-saved_searches_key_id_seq"
 
 
 --
--- TOC entry 3118 (class 0 OID 0)
+-- TOC entry 3128 (class 0 OID 0)
 -- Dependencies: 197
 -- Name: tags-saved_searches_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -333,7 +354,7 @@ CREATE SEQUENCE tags_key_id_seq
 
 
 --
--- TOC entry 3119 (class 0 OID 0)
+-- TOC entry 3129 (class 0 OID 0)
 -- Dependencies: 191
 -- Name: tags_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -371,7 +392,7 @@ CREATE SEQUENCE users_key_id_seq
 
 
 --
--- TOC entry 3120 (class 0 OID 0)
+-- TOC entry 3130 (class 0 OID 0)
 -- Dependencies: 189
 -- Name: users_key_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
@@ -380,7 +401,7 @@ ALTER SEQUENCE users_key_id_seq OWNED BY users.key_id;
 
 
 --
--- TOC entry 2941 (class 2604 OID 4639379)
+-- TOC entry 2946 (class 2604 OID 4639379)
 -- Name: listings key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -388,7 +409,7 @@ ALTER TABLE ONLY listings ALTER COLUMN key_id SET DEFAULT nextval('listings_key_
 
 
 --
--- TOC entry 2963 (class 2604 OID 4640488)
+-- TOC entry 2968 (class 2604 OID 4640488)
 -- Name: listings-saved_searches key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -396,7 +417,7 @@ ALTER TABLE ONLY "listings-saved_searches" ALTER COLUMN key_id SET DEFAULT nextv
 
 
 --
--- TOC entry 2956 (class 2604 OID 4640391)
+-- TOC entry 2961 (class 2604 OID 4640391)
 -- Name: saved_searches key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -404,7 +425,7 @@ ALTER TABLE ONLY saved_searches ALTER COLUMN key_id SET DEFAULT nextval('saved_s
 
 
 --
--- TOC entry 2945 (class 2604 OID 4639456)
+-- TOC entry 2950 (class 2604 OID 4639456)
 -- Name: seeks key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -412,7 +433,7 @@ ALTER TABLE ONLY seeks ALTER COLUMN key_id SET DEFAULT nextval('seeks_key_id_seq
 
 
 --
--- TOC entry 2965 (class 2604 OID 5649587)
+-- TOC entry 2970 (class 2604 OID 5649587)
 -- Name: starred_listings key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -420,7 +441,7 @@ ALTER TABLE ONLY starred_listings ALTER COLUMN key_id SET DEFAULT nextval('starr
 
 
 --
--- TOC entry 2954 (class 2604 OID 4639971)
+-- TOC entry 2959 (class 2604 OID 4639971)
 -- Name: tags key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -428,7 +449,7 @@ ALTER TABLE ONLY tags ALTER COLUMN key_id SET DEFAULT nextval('tags_key_id_seq':
 
 
 --
--- TOC entry 2959 (class 2604 OID 4640443)
+-- TOC entry 2964 (class 2604 OID 4640443)
 -- Name: tags-listings key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -436,7 +457,7 @@ ALTER TABLE ONLY "tags-listings" ALTER COLUMN key_id SET DEFAULT nextval('"tags-
 
 
 --
--- TOC entry 2961 (class 2604 OID 4640457)
+-- TOC entry 2966 (class 2604 OID 4640457)
 -- Name: tags-saved_searches key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -444,7 +465,7 @@ ALTER TABLE ONLY "tags-saved_searches" ALTER COLUMN key_id SET DEFAULT nextval('
 
 
 --
--- TOC entry 2949 (class 2604 OID 4639700)
+-- TOC entry 2954 (class 2604 OID 4639700)
 -- Name: users key_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -452,7 +473,7 @@ ALTER TABLE ONLY users ALTER COLUMN key_id SET DEFAULT nextval('users_key_id_seq
 
 
 --
--- TOC entry 2985 (class 2606 OID 4640491)
+-- TOC entry 2993 (class 2606 OID 4640491)
 -- Name: listings-saved_searches listings-saved_searches_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -461,7 +482,7 @@ ALTER TABLE ONLY "listings-saved_searches"
 
 
 --
--- TOC entry 2969 (class 2606 OID 4639385)
+-- TOC entry 2977 (class 2606 OID 4639385)
 -- Name: listings listings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -470,7 +491,16 @@ ALTER TABLE ONLY listings
 
 
 --
--- TOC entry 2979 (class 2606 OID 4640398)
+-- TOC entry 2997 (class 2606 OID 7022059)
+-- Name: new_listings new_listings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY new_listings
+    ADD CONSTRAINT new_listings_pkey PRIMARY KEY (key_id);
+
+
+--
+-- TOC entry 2987 (class 2606 OID 4640398)
 -- Name: saved_searches saved_searches_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -479,7 +509,7 @@ ALTER TABLE ONLY saved_searches
 
 
 --
--- TOC entry 2971 (class 2606 OID 4639459)
+-- TOC entry 2979 (class 2606 OID 4639459)
 -- Name: seeks seeks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -488,7 +518,7 @@ ALTER TABLE ONLY seeks
 
 
 --
--- TOC entry 2987 (class 2606 OID 5649589)
+-- TOC entry 2995 (class 2606 OID 5649589)
 -- Name: starred_listings starred_listings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -497,7 +527,7 @@ ALTER TABLE ONLY starred_listings
 
 
 --
--- TOC entry 2981 (class 2606 OID 4640446)
+-- TOC entry 2989 (class 2606 OID 4640446)
 -- Name: tags-listings tags-listings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -506,7 +536,7 @@ ALTER TABLE ONLY "tags-listings"
 
 
 --
--- TOC entry 2983 (class 2606 OID 4640460)
+-- TOC entry 2991 (class 2606 OID 4640460)
 -- Name: tags-saved_searches tags-saved_searches_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -515,7 +545,7 @@ ALTER TABLE ONLY "tags-saved_searches"
 
 
 --
--- TOC entry 2975 (class 2606 OID 4639974)
+-- TOC entry 2983 (class 2606 OID 4639974)
 -- Name: tags tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -524,7 +554,7 @@ ALTER TABLE ONLY tags
 
 
 --
--- TOC entry 2977 (class 2606 OID 4640149)
+-- TOC entry 2985 (class 2606 OID 4640149)
 -- Name: tags uniq_name; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -533,7 +563,7 @@ ALTER TABLE ONLY tags
 
 
 --
--- TOC entry 2973 (class 2606 OID 4639703)
+-- TOC entry 2981 (class 2606 OID 4639703)
 -- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -541,7 +571,7 @@ ALTER TABLE ONLY users
     ADD CONSTRAINT users_pkey PRIMARY KEY (key_id);
 
 
--- Completed on 2017-05-07 23:09:18 EDT
+-- Completed on 2017-05-08 03:59:54 EDT
 
 --
 -- PostgreSQL database dump complete


### PR DESCRIPTION
When running all saved searches at regular intervals, we will run
against this table, since it will hold fewer listings and thus be much
faster.

Code that uses this isn't ready but the database is like this now. It doesn't break anything, only adds a new table almost exactly like listings.